### PR TITLE
Remove redundant cleaning of URL in route()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 *.log
 __pycache__
+.venv/
 
 
 # Docs
@@ -20,3 +21,6 @@ Vagrantfile
 # Examples
 examples/*.sqlite3
 examples/*migrations*
+
+# OS-specific
+.DS_Store

--- a/nanodjango/app.py
+++ b/nanodjango/app.py
@@ -121,8 +121,7 @@ class Django:
         """
         # We want to support Flask-like patterns which have leading / in its patterns.
         # Django does not use these, so strip them out.
-        if pattern.startswith("/"):
-            pattern = pattern[1:]
+        pattern = pattern.removeprefix("/")
 
         def wrapped(fn):
             # Store route for convert lookup
@@ -134,7 +133,7 @@ class Django:
 
             # Register URL
             urlpatterns.append(
-                url_path(pattern.removeprefix("/"), string_view(fn), name=fn.__name__)
+                url_path(pattern, string_view(fn), name=fn.__name__)
             )
             return fn
 


### PR DESCRIPTION
Remove leading slash from URL pattern in `route()` once, before entering `wrapped()`.

Also, update .gitignore to ignore .venv/, and .DS_Store for Mac users.