### PR TITLE
Fix kwarg handling in string_view decorator

### DIFF
--- a/nanodjango/app.py
+++ b/nanodjango/app.py
@@ -180,9 +180,9 @@ class Django:
                 return f"Hello {pk}"
 
             # re_path() parameters
-            @app.route("/(?P<slug>[a-z]/", re=True)
-            def view(request, char):
-                return f"Hello {char}"
+            @app.route("/(?P<slug>[a-z])/", re=True)
+            def view(request, slug):
+                return f"Hello {slug}"
 
             # Include another urlconf
             # Note this is called as a function, not a decorator

--- a/nanodjango/views.py
+++ b/nanodjango/views.py
@@ -10,15 +10,15 @@ def string_view(fn):
     """
     if inspect.iscoroutinefunction(fn):
 
-        async def django_view(request):
+        async def django_view(request, **kwargs):
             response = await fn(request)
             if isinstance(response, HttpResponse):
                 return response
             return HttpResponse(response)
     else:
 
-        def django_view(request):
-            response = fn(request)
+        def django_view(request, **kwargs):
+            response = fn(request, **kwargs)
             if isinstance(response, HttpResponse):
                 return response
             return HttpResponse(response)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,51 @@
+import pytest
+from django.test import Client
+
+from nanodjango import Django
+
+app = Django()
+
+
+# No parameters
+@app.route("/")
+def view(request):
+    return "Hello"
+
+
+# path() parameters
+@app.route("/<int:pk>/")
+def view(request, pk):
+    return f"Hello {pk}"
+
+
+# re_path() parameters
+@app.route("/(?P<slug>[a-z])/", re=True)
+def view(request, slug):
+    return f"Hello {slug}"
+
+
+"""
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def client():
+    return Client()
+
+
+def test_get(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.content == b"Hello"
+
+
+def test_get_with_param(client):
+    response = client.get("/123/")
+    assert response.status_code == 200
+    assert response.content == b"Hello 123"
+
+
+def test_get_with_re_param(client):
+    response = client.get("/a/")
+    assert response.status_code == 200
+    assert response.content == b"Hello a"


### PR DESCRIPTION
I noticed that path parameters weren't being passed to view functions when using the string_view decorator.

* Modified string_view to accept and pass **kwargs to view functions
* Added tests to verify correct handling of some view route logic (example codes were from Django.route docstring)

Let me know if you have any questions. Thanks for considering this!