### PR TITLE
Refacto function string-view in  view

### DIFF
--- a/nanodjango/views.py
+++ b/nanodjango/views.py
@@ -8,19 +8,19 @@ def string_view(fn):
     Wrapper to automatically convert the response from a view function into an
     HttpResponse to support returning a string.
     """
-    if inspect.iscoroutinefunction(fn):
 
+    def make_response(response):
+        if isinstance(response, HttpResponse):
+            return response
+        return HttpResponse(response)
+
+    if inspect.iscoroutinefunction(fn):
         async def django_view(request, **kwargs):
             response = await fn(request)
-            if isinstance(response, HttpResponse):
-                return response
-            return HttpResponse(response)
+            return make_response(response)
     else:
-
         def django_view(request, **kwargs):
             response = fn(request, **kwargs)
-            if isinstance(response, HttpResponse):
-                return response
-            return HttpResponse(response)
+            return make_response(response)
 
     return django_view


### PR DESCRIPTION
While functional, the old code was a bit more verbose and repetitive. Each branch had its own logic for converting the response to an HttpResponse, which made it slightly harder to maintain if the conversion logic needed to be changed. With the make_response function, you centralize this logic in one place, making the code more readable and reusable. Additionally, if you want to change the response conversion behavior (e.g. add an HTTP header or other logic), you only need to do it in one place, making it easier to maintain in the long run.