### PR TITLE
Integrate DJP

### DIFF
--- a/nanodjango/settings.py
+++ b/nanodjango/settings.py
@@ -6,6 +6,8 @@ from os import getenv
 from pathlib import Path
 from types import ModuleType
 
+import djp
+
 from nanodjango.app_meta import get_app_conf, get_app_module
 
 app_conf = get_app_conf()
@@ -130,3 +132,6 @@ API_URL = "api/"
 
 # Directory containing public files
 PUBLIC_DIR = BASE_DIR / "public"
+
+# Initialize djp
+djp.settings(globals())

--- a/nanodjango/urls.py
+++ b/nanodjango/urls.py
@@ -1,5 +1,6 @@
 # Will be populated at runtime
 from django.urls.resolvers import URLPattern, URLResolver
+import djp
 
 
-urlpatterns: list[URLPattern | URLResolver] = []
+urlpatterns: list[URLPattern | URLResolver] = djp.urlpatterns()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "isort",
     "Django>=3.2",
     "django-ninja",
+    "djp",
     "uvicorn",
     "whitenoise",
 ]


### PR DESCRIPTION
This pull request adds support for Simon Willison's (@simonw) [DJP](https://simonwillison.net/2024/Sep/25/djp-a-plugin-system-for-django/) project.

DJP allows users to add plugins to Django by simply installing a package. I.e. to install the debug toolbar, one simply has to run `pip install django-plugin-django-debug-toolbar` and that's it.

While still very new, this approach seems to align pretty well with the ideas behind nanodjango. 
This PR is still rough and would need documentation changes. It does however seem to work, based on my initial testing.

What do you think? Is this interesting to you?
If so, I'd happily adjust the docs accordingly (or add a test - though I'm not entirely sure what would be tested).