### PR TITLE
Fix uwsgi instructions

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -193,7 +193,7 @@ server directly:
 .. code-block:: bash
 
     gunicorn -w 4 counter:app
-    uwsgi --wsgi-file counter.py --callable app --processes 4
+    uwsgi --module counter:app --processes 4
     uvicorn counter:app
 
 


### PR DESCRIPTION
The uwsgi instructions seem to be incorrect. It doesn't complain when starting but does when trying to load a page.

The instruction might also benefit from adding -s <filename> or --http 0.0.0.0:8000 (one of the 2)

(tested with uwsgi 2.0.20 and 2.0.28)