### PR TITLE
Added create_server function

### DIFF
--- a/nanodjango/app.py
+++ b/nanodjango/app.py
@@ -742,4 +742,16 @@ class Django:
         application = get_wsgi_application()
         return application(environ, start_response)
 
+    async def create_server(self, host, port):
+        """
+        Initalizes nanodjango and returns a ASGI server instance
+        """
+        self._has_async_view = True 
+        type(self).__call__ = type(self).asgi # Same hacky solution in wrapped()
+
+        import uvicorn
+        config = uvicorn.Config(self, host=host, port=port)
+        server = uvicorn.Server(config)
+        await server.serve()
+
     __call__ = wsgi


### PR DESCRIPTION
This allows nanodjango to be ran as an async function.

Wasn't sure how to test since creating the server is blocking. Would creating threads in the test suite be sufficient? Or a different method would be appropriate?

 