### PR TITLE
Add settings callback support

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -40,3 +40,24 @@ to configure itself and to simplify configuring Django:
 ``PUBLIC_DIR``
   If set, nanodjango will use it to set ``WHITENOISE_ROOT``, so any files inside are
   served from the site root. Useful for ``favicon.ico``, ``robots.txt`` etc.
+
+
+Settings callbacks
+==================
+
+You can use callbacks to modify nanodjango's default settings rather than replacing
+them entirely. If you pass a callable for a setting that already exists in
+nanodjango's defaults, it will be called with the current value and the return
+value will be used::
+
+    app = Django(
+        MIDDLEWARE=lambda m: [MyPreMiddleware] + m + [MyPostMiddleware],
+        INSTALLED_APPS=lambda apps: [a for a in apps if "admin" not in a],
+    )
+
+This is useful for prepending or appending to list settings like ``MIDDLEWARE`` or
+``INSTALLED_APPS``, or for filtering out unwanted defaults.
+
+Note that this only applies to settings that already exist in nanodjango's defaults.
+For new settings that don't exist yet, callable values are stored as-is (this allows
+you to pass callable settings like ``WHITENOISE_ADD_HEADERS_FUNCTION``).

--- a/nanodjango/app.py
+++ b/nanodjango/app.py
@@ -160,7 +160,12 @@ class Django:
         self.settings = settings
 
         # Update Django settings with ours
+        # If a value is callable and the setting already exists, treat it as a callback
+        # that receives the current value and returns the new value. This allows users
+        # to modify default settings (e.g. MIDDLEWARE=lambda m: [MyMiddleware] + m)
         for key, value in _settings.items():
+            if callable(value) and hasattr(settings, key):
+                value = value(getattr(settings, key))
             setattr(settings, key, value)
 
         # Set WHITENOISE_ROOT if public dir exists

--- a/tests/test_settings_callbacks.py
+++ b/tests/test_settings_callbacks.py
@@ -1,13 +1,11 @@
 """Tests for settings callback support (issue #74)"""
 
-import subprocess
-import sys
+from nanodjango.testing.utils import run_app_code
 
 
-def test_settings_callback_middleware(tmp_path):
+def test_settings_callback_middleware():
     """Test that a callback can modify MIDDLEWARE"""
-    app_file = tmp_path / "callback_app.py"
-    app_file.write_text('''
+    result = run_app_code('''
 from nanodjango import Django
 
 app = Django(
@@ -24,21 +22,14 @@ print("MIDDLEWARE_FIRST:", settings.MIDDLEWARE[0])
 print("MIDDLEWARE_LAST:", settings.MIDDLEWARE[-1])
 ''')
 
-    result = subprocess.run(
-        [sys.executable, str(app_file)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "MIDDLEWARE_FIRST: test.FirstMiddleware" in result.stdout
     assert "MIDDLEWARE_LAST: test.LastMiddleware" in result.stdout
 
 
-def test_settings_callback_installed_apps(tmp_path):
+def test_settings_callback_installed_apps():
     """Test that a callback can filter INSTALLED_APPS"""
-    app_file = tmp_path / "callback_app.py"
-    app_file.write_text('''
+    result = run_app_code('''
 from nanodjango import Django
 
 # Use callback to remove admin from installed apps
@@ -55,21 +46,14 @@ print("HAS_ADMIN:", "django.contrib.admin" in settings.INSTALLED_APPS)
 print("HAS_AUTH:", "django.contrib.auth" in settings.INSTALLED_APPS)
 ''')
 
-    result = subprocess.run(
-        [sys.executable, str(app_file)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "HAS_ADMIN: False" in result.stdout  # Admin was removed by callback
     assert "HAS_AUTH: True" in result.stdout  # Other apps preserved
 
 
-def test_settings_literal_callable_for_new_setting(tmp_path):
+def test_settings_literal_callable_for_new_setting():
     """Test that callable values for NEW settings are kept as-is (not called)"""
-    app_file = tmp_path / "callable_app.py"
-    app_file.write_text('''
+    result = run_app_code('''
 from nanodjango import Django
 
 def my_header_func(headers, request, file):
@@ -89,21 +73,14 @@ print("IS_CALLABLE:", callable(settings.WHITENOISE_ADD_HEADERS_FUNCTION))
 print("FUNC_NAME:", settings.WHITENOISE_ADD_HEADERS_FUNCTION.__name__)
 ''')
 
-    result = subprocess.run(
-        [sys.executable, str(app_file)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "IS_CALLABLE: True" in result.stdout
     assert "FUNC_NAME: my_header_func" in result.stdout
 
 
-def test_settings_non_callable_unchanged(tmp_path):
+def test_settings_non_callable_unchanged():
     """Test that non-callable values still work normally"""
-    app_file = tmp_path / "normal_app.py"
-    app_file.write_text('''
+    result = run_app_code('''
 from nanodjango import Django
 
 app = Django(
@@ -120,12 +97,6 @@ print("DEBUG:", settings.DEBUG)
 print("HOSTS:", ",".join(settings.ALLOWED_HOSTS))
 ''')
 
-    result = subprocess.run(
-        [sys.executable, str(app_file)],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
-    )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert "DEBUG: False" in result.stdout
     assert "HOSTS: example.com,localhost" in result.stdout

--- a/tests/test_settings_callbacks.py
+++ b/tests/test_settings_callbacks.py
@@ -1,0 +1,131 @@
+"""Tests for settings callback support (issue #74)"""
+
+import subprocess
+import sys
+
+
+def test_settings_callback_middleware(tmp_path):
+    """Test that a callback can modify MIDDLEWARE"""
+    app_file = tmp_path / "callback_app.py"
+    app_file.write_text('''
+from nanodjango import Django
+
+app = Django(
+    MIDDLEWARE=lambda m: ["test.FirstMiddleware"] + m + ["test.LastMiddleware"]
+)
+
+@app.route("/")
+def index(request):
+    return "Hello"
+
+# Print the middleware to verify callback was applied
+from django.conf import settings
+print("MIDDLEWARE_FIRST:", settings.MIDDLEWARE[0])
+print("MIDDLEWARE_LAST:", settings.MIDDLEWARE[-1])
+''')
+
+    result = subprocess.run(
+        [sys.executable, str(app_file)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "MIDDLEWARE_FIRST: test.FirstMiddleware" in result.stdout
+    assert "MIDDLEWARE_LAST: test.LastMiddleware" in result.stdout
+
+
+def test_settings_callback_installed_apps(tmp_path):
+    """Test that a callback can filter INSTALLED_APPS"""
+    app_file = tmp_path / "callback_app.py"
+    app_file.write_text('''
+from nanodjango import Django
+
+# Use callback to remove admin from installed apps
+app = Django(
+    INSTALLED_APPS=lambda apps: [a for a in apps if "admin" not in a]
+)
+
+@app.route("/")
+def index(request):
+    return "Hello"
+
+from django.conf import settings
+print("HAS_ADMIN:", "django.contrib.admin" in settings.INSTALLED_APPS)
+print("HAS_AUTH:", "django.contrib.auth" in settings.INSTALLED_APPS)
+''')
+
+    result = subprocess.run(
+        [sys.executable, str(app_file)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "HAS_ADMIN: False" in result.stdout  # Admin was removed by callback
+    assert "HAS_AUTH: True" in result.stdout  # Other apps preserved
+
+
+def test_settings_literal_callable_for_new_setting(tmp_path):
+    """Test that callable values for NEW settings are kept as-is (not called)"""
+    app_file = tmp_path / "callable_app.py"
+    app_file.write_text('''
+from nanodjango import Django
+
+def my_header_func(headers, request, file):
+    return headers
+
+app = Django(
+    WHITENOISE_ADD_HEADERS_FUNCTION=my_header_func
+)
+
+@app.route("/")
+def index(request):
+    return "Hello"
+
+from django.conf import settings
+# Should be the function itself, not the result of calling it
+print("IS_CALLABLE:", callable(settings.WHITENOISE_ADD_HEADERS_FUNCTION))
+print("FUNC_NAME:", settings.WHITENOISE_ADD_HEADERS_FUNCTION.__name__)
+''')
+
+    result = subprocess.run(
+        [sys.executable, str(app_file)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "IS_CALLABLE: True" in result.stdout
+    assert "FUNC_NAME: my_header_func" in result.stdout
+
+
+def test_settings_non_callable_unchanged(tmp_path):
+    """Test that non-callable values still work normally"""
+    app_file = tmp_path / "normal_app.py"
+    app_file.write_text('''
+from nanodjango import Django
+
+app = Django(
+    DEBUG=False,
+    ALLOWED_HOSTS=["example.com", "localhost"]
+)
+
+@app.route("/")
+def index(request):
+    return "Hello"
+
+from django.conf import settings
+print("DEBUG:", settings.DEBUG)
+print("HOSTS:", ",".join(settings.ALLOWED_HOSTS))
+''')
+
+    result = subprocess.run(
+        [sys.executable, str(app_file)],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "DEBUG: False" in result.stdout
+    assert "HOSTS: example.com,localhost" in result.stdout


### PR DESCRIPTION
## Summary

- Allow using callbacks to modify default settings rather than replacing them
- If a setting value is callable and the setting already exists in nanodjango's defaults, call it with the current value and use the return value
- Add `run_app_code` test helper for creating and running temporary nanodjango apps

Example:
```python
app = Django(
    MIDDLEWARE=lambda m: [MyPreMiddleware] + m + [MyPostMiddleware],
    INSTALLED_APPS=lambda apps: [a for a in apps if "admin" not in a],
)
```

Closes #74

## Test plan

- [x] Test callback modifies MIDDLEWARE
- [x] Test callback filters INSTALLED_APPS  
- [x] Test literal callable for new settings (like WHITENOISE_ADD_HEADERS_FUNCTION) is kept as-is
- [x] Test non-callable values work normally