### PR TITLE
Fix Windows compatibility: default host 0.0.0.0:8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Anything you would normally do with `manage.py` you can do with `nanodjango mana
 ```sh
 nanodjango manage script.py check
 nanodjango manage script.py makemigrations script
-nanodjango manage script.py runserver 0:8000
+nanodjango manage script.py runserver 0.0.0.0:8000
 ```
 
 ### Run in production

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -217,6 +217,6 @@ many cases it should run straight away:
 .. code-block:: bash
 
     cd /path/to/site
-    ./manage.py runserver 0:8000
+    ./manage.py runserver 0.0.0.0:8000
 
 For full details on how to use nanodjango's ``convert`` command, see :doc:`convert`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -141,13 +141,13 @@ commands on your app::
     nanodjango manage <script.py> [<command>]
 
 
-If the management command is left out, it will default to ``runserver 0:8000`` - these
+If the management command is left out, it will default to ``runserver 0.0.0.0:8000`` - these
 two commands are equivalent:
 
 .. code-block:: bash
 
     nanodjango manage counter.py
-    nanodjango manage counter.py runserver 0:8000
+    nanodjango manage counter.py runserver 0.0.0.0:8000
 
 
 You can perform any management command:

--- a/examples/scale/scale.py
+++ b/examples/scale/scale.py
@@ -11,7 +11,7 @@ Usage::
 
     nanodjango convert scale.py /path/to/site --name=myproject
     cd /path/to/site
-    ./manage.py runserver 0:8000
+    ./manage.py runserver 0.0.0.0:8000
 """
 # /// script
 # dependencies = ["nanodjango"]

--- a/nanodjango/app.py
+++ b/nanodjango/app.py
@@ -647,7 +647,7 @@ class Django:
         * Uses uvicorn for async views, Django's runserver otherwise
 
         Args:
-            host: Host and port in format ``"host:port"`` (default: ``"0:8000"``)
+            host: Host and port in format ``"host:port"`` (default: ``"0.0.0.0:8000"``)
 
         Example::
 
@@ -689,7 +689,7 @@ class Django:
         * Sets ``DEBUG=False`` if not explicitly configured
 
         Args:
-            host: Host and port in format ``"host:port"`` (default: ``"0:8000"``)
+            host: Host and port in format ``"host:port"`` (default: ``"0.0.0.0:8000"``)
 
         Raises:
             UsageError: If gunicorn (for WSGI) or uvicorn (for ASGI) is not installed
@@ -791,14 +791,14 @@ class Django:
             elif len(sys.argv) == 2:
                 host = sys.argv[1]
             else:
-                host = "0:8000"
+                host = "0.0.0.0:8000"
 
         port = 8000
         if ":" in host:
             host, _port = host.split(":")
             port = int(_port)
         elif not host:
-            host = "0"
+            host = "0.0.0.0"
 
         exec_manage("makemigrations", self.app_name)
         exec_manage("migrate")


### PR DESCRIPTION
## Summary

Change default host from `0:8000` to `0.0.0.0:8000` to fix Windows compatibility.

The `0` shorthand is a Django quirk that works on Unix but fails on Windows with `getaddrinfo failed`.

Fixes #45